### PR TITLE
Fetch-Package: Added optional Output parameter to specify where packa…

### DIFF
--- a/psmake/ChangeLog.txt
+++ b/psmake/ChangeLog.txt
@@ -1,6 +1,11 @@
 PsMake
 ========================================
 
+Version 3.1.5.0
+----------------------------------------
+Core functions:
+(Change) Fetch-Package: Added optional Output parameter to specify where packages should be installed
+
 Version 3.1.4.0
 ----------------------------------------
 Core functions:

--- a/psmake/ext/psmake.core.ps1
+++ b/psmake/ext/psmake.core.ps1
@@ -102,7 +102,9 @@ function Fetch-Package(
     # Package name to fetch
     $name,
     # Package version to fetch 
-    $version)
+    $version,
+    # Optional output directory for packages
+    $output)
 {
 	function Find-Package($packagesDir, $name, $version)
 	{
@@ -121,8 +123,13 @@ function Fetch-Package(
 	}
 
 	Write-Host "Fetching $name ver. $version..."
-	if (!$Context.MakeDirectory) {$packageDir='packages'}
-	else {$packageDir="$($Context.MakeDirectory)\packages"}
+    if ($output) {        
+        if (-not(Test-Path $output)) { New-Item $output -ItemType Directory -Force -ErrorAction SilentlyContinue > null }
+        $packageDir = $output
+    } else {
+        if (!$Context.MakeDirectory) {$packageDir='packages'}
+	    else {$packageDir="$($Context.MakeDirectory)\packages"}
+    }	
 	
 	$package = Find-Package $packageDir $name $version
     if ($package -ne $null) 

--- a/psmake/ext/psmake.core.ps1
+++ b/psmake/ext/psmake.core.ps1
@@ -124,7 +124,7 @@ function Fetch-Package(
 
 	Write-Host "Fetching $name ver. $version..."
     if ($output) {        
-        if (-not(Test-Path $output)) { New-Item $output -ItemType Directory -Force -ErrorAction SilentlyContinue > null }
+        if (-not(Test-Path $output)) { New-Item $output -ItemType Directory -Force -ErrorAction SilentlyContinue > $null }
         $packageDir = $output
     } else {
         if (!$Context.MakeDirectory) {$packageDir='packages'}

--- a/psmake/package.nuspec
+++ b/psmake/package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>psmake</id>
-    <version>3.1.4.0</version>
+    <version>3.1.5.0</version>
 	<title>PSMake</title>
     <authors>Wojciech Kotlarski</authors>
     <owners>Wojciech Kotlarski</owners>
@@ -14,8 +14,7 @@
     <language>en-US</language>
     <description>A PowerShell based tool which controls a software project build process.</description>
 	<releaseNotes>Core functions:
-(Fix) Call-Program: if executed command prints error on stderr but returns 0, Call-Program does not throw
-(Change) Call-Program: uses $LastExitCode instead $? to detect if operation was successful</releaseNotes>
+(Change) Fetch-Package: Added optional Output parameter to specify where packages should be installed</releaseNotes>
   </metadata>
   <files>
     <file src="**\*" target="." exclude="**\*.nuspec"/>


### PR DESCRIPTION
Please consider this PR. This will allow the installation of packages to specified output folder and prevent a lot of repetitive tasks. i.e. Install Package to make\packages, get path returned, then see if destination folder exits, create if not and then finally copy from make\packages to destination