### PR TITLE
Fix for https://github.com/Suremaker/PsMake/issues/10

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ A PowerShell based tool which controls a software project build process.
 
 Please execute following commands:
 ```
+Windows
 nuget.exe install psmake -version 3.1.0.0
+
+Powershell Core
+Register-PackageSource -name Nuget.Org -Location "http://www.nuget.org/api/v2" -ProviderName NuGet
+Install-Package PsMake -RequiredVersion 3.1.0.0 -Destination ".\" -ProviderName NuGet 
+
 .\psmake.3.1.0.0\psmake.ps1 -Scaffold empty
 ls
 ```

--- a/psmake/ext/psmake.scaffold.ps1
+++ b/psmake/ext/psmake.scaffold.ps1
@@ -49,8 +49,15 @@ function private:Get-NuGetArgs (`$params, `$defaultSource)
 	return @()
 }
 
-`$private:srcArgs = Get-NuGetArgs `$args `$PsMakeNugetSource
-$($Context.NuGetExe) install psmake -Version `$PsMakeVer -OutputDirectory $($Context.MakeDirectory) $nuArgs @srcArgs
+if (`$PSVersionTable["PSVersion"].Major -ge 5) {
+  Write-Host "Installing using Powershell Package Manager"
+  Install-Package PsMake -RequiredVersion `$PsMakeVer -Destination "`$pwd\make" -ProviderName nuget -Force
+} 
+else {
+  Write-Host "Installing using Nuget"
+  `$private:srcArgs = Get-NuGetArgs `$args `$PsMakeNugetSource
+  $($Context.NuGetExe) install psmake -Version `$PsMakeVer -OutputDirectory $($Context.MakeDirectory) $nuArgs @srcArgs
+}
 & `"$($Context.MakeDirectory)\psmake.`$PsMakeVer\psmake.ps1`" -md $($Context.MakeDirectory) @args
 "@
 	


### PR DESCRIPTION
We want to start using PsMake on Powershell Core and the dependency on nuget.exe is a problem. We can use Powershell Package Manager and register Nuget.org as a source and avoid using Nuget.exe