### PR TITLE
Made OpenCover profiler parametric

### DIFF
--- a/psmake.mod.testing/ChangeLog.txt
+++ b/psmake.mod.testing/ChangeLog.txt
@@ -1,6 +1,10 @@
 PsMake Testing Module
 ========================================
 
+Version 1.3.1.1
+----------------------------------------
+(Change) Run-OpenCover: added $profiler argument to support windows Local System account.
+
 Version 1.3.1.0
 ----------------------------------------
 (Change) Generate-CoverageSummary: added support for ReportGenerator 2.x series and set 2.5.3 version as default one

--- a/psmake.mod.testing/internals.ps1
+++ b/psmake.mod.testing/internals.ps1
@@ -8,7 +8,7 @@ function Prepare-ReportDirectory($ReportDirectory, $erase)
 	mkdir $ReportDirectory -ErrorAction SilentlyContinue | Out-Null
 }
 
-function Run-OpenCover($OpenCoverVersion, $Runner, $RunnerArgs, $CodeFilter, $TestFilter, $Output)
+function Run-OpenCover($OpenCoverVersion, $Runner, $RunnerArgs, $CodeFilter, $TestFilter, $Output, $Profiler)
 {
 	function Find-OpenCoverExe([string[]]$paths){
 		foreach($path in $paths){
@@ -22,7 +22,7 @@ function Run-OpenCover($OpenCoverVersion, $Runner, $RunnerArgs, $CodeFilter, $Te
 	$openCoverConsole = Find-OpenCoverExe "$openCoverPath\tools\OpenCover.Console.exe", "$openCoverPath\OpenCover.Console.exe"
 
 	Write-ShortStatus "Running tests with OpenCover"
-	call "$openCoverConsole" "-log:Error" "-showunvisited" "-register:user" "-target:$Runner"  "-filter:$CodeFilter" "-output:$Output" "-returntargetcode" "-coverbytest:$TestFilter" "-targetargs:$RunnerArgs"
+	call "$openCoverConsole" "-log:Error" "-showunvisited" "-register:$Profiler" "-target:$Runner"  "-filter:$CodeFilter" "-output:$Output" "-returntargetcode" "-coverbytest:$TestFilter" "-targetargs:$RunnerArgs"
 }
 
 function Resolve-TestAssemblies

--- a/psmake.mod.testing/package.nuspec
+++ b/psmake.mod.testing/package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>psmake.mod.testing</id>
-    <version>1.3.1.0</version>
+    <version>1.3.1.1</version>
     <title>PSMake Testing mod</title>
     <authors>Wojciech Kotlarski</authors>
     <owners>Wojciech Kotlarski</owners>
@@ -14,8 +14,7 @@
     <language>en-US</language>
     <description>A testing module for PsMake, allowing to execute nunit/nunit3/mbunit/mstest/xunit/dotnet tests with optional coverage check</description>
     <releaseNotes>Functions:
-(Change) Generate-CoverageSummary: added support for ReportGenerator 2.x series and set 2.5.3 version as default one
-(Change) Check-AcceptableCoverage: added support for ReportGenerator 2.x series xml report format
+   (Change) Run-OpenCover: added $profiler argument to support windows Local System account
 </releaseNotes>
   </metadata>
   <files>

--- a/psmake.mod.testing/psmake.mod.testing.ps1
+++ b/psmake.mod.testing/psmake.mod.testing.ps1
@@ -448,7 +448,13 @@ function Run-Tests
         # OpenCover version. By default it is: 4.6.519
         [ValidateNotNullOrEmpty()]
         [ValidatePattern("^[0-9]+(\.[0-9]+){0,3}$")]
-        [string]$OpenCoverVersion="4.6.519"
+        [string]$OpenCoverVersion="4.6.519",
+
+        [Parameter()]
+        # Code coverage profiler. 
+        # use "Path32 " or "Path64" to let opencover select the profiler for you. 
+        [ValidateNotNullOrEmpty()]
+        [string]$Profiler = "user"
     )
     begin
     {
@@ -477,7 +483,7 @@ function Run-Tests
         else
         {    
             $CoverageReport = "$ReportDirectory\$($_.ReportName)_coverage.xml"
-            Run-OpenCover -OpenCoverVersion $OpenCoverVersion -Runner $runner -RunnerArgs $runnerArgs -CodeFilter $CodeFilter -TestFilter $TestFilter -Output $CoverageReport
+            Run-OpenCover -OpenCoverVersion $OpenCoverVersion -Runner $runner -RunnerArgs $runnerArgs -CodeFilter $CodeFilter -TestFilter $TestFilter -Output $CoverageReport -Profiler $Profiler
 
             $coverageReports += $CoverageReport
         }


### PR DESCRIPTION
hi.
When Jenkins service is running under Local system account instead of a specific user (e.g. builduser),
OpenCover returns 0% code coverage due to lack of enough privilege.

I made the OpenCover profiler to be parametric, and its backward compatible. 
If you leave it empty, it will be set to default (-register:user)
otherwise, based on your operation system, you can choose Path32 or Path64 to let OpenCover figure out its profiler. 

Documentation about profiler:
https://github.com/opencover/opencover/wiki/Usage

An example of raised issue by someone else:
https://github.com/OpenCover/opencover/issues/167

