### PR TITLE
Code coverage for .net core 2.

### DIFF
--- a/psmake.mod.testing/ChangeLog.txt
+++ b/psmake.mod.testing/ChangeLog.txt
@@ -1,6 +1,10 @@
 PsMake Testing Module
 ========================================
 
+Version 1.3.2.0
+----------------------------------------
+(Change) Run-OpenCover: added -oldStyle flag to allow code coverage of .net core 2 assemblies.
+
 Version 1.3.1.1
 ----------------------------------------
 (Change) Run-OpenCover: added $profiler argument to support windows Local System account.

--- a/psmake.mod.testing/internals.ps1
+++ b/psmake.mod.testing/internals.ps1
@@ -22,7 +22,7 @@ function Run-OpenCover($OpenCoverVersion, $Runner, $RunnerArgs, $CodeFilter, $Te
 	$openCoverConsole = Find-OpenCoverExe "$openCoverPath\tools\OpenCover.Console.exe", "$openCoverPath\OpenCover.Console.exe"
 
 	Write-ShortStatus "Running tests with OpenCover"
-	call "$openCoverConsole" "-log:Error" "-showunvisited" "-register:$Profiler" "-target:$Runner"  "-filter:$CodeFilter" "-output:$Output" "-returntargetcode" "-coverbytest:$TestFilter" "-targetargs:$RunnerArgs"
+	call "$openCoverConsole" "-oldStyle" "-log:Error" "-showunvisited" "-register:$Profiler" "-target:$Runner"  "-filter:$CodeFilter" "-output:$Output" "-returntargetcode" "-coverbytest:$TestFilter" "-targetargs:$RunnerArgs"
 }
 
 function Resolve-TestAssemblies

--- a/psmake.mod.testing/package.nuspec
+++ b/psmake.mod.testing/package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>psmake.mod.testing</id>
-    <version>1.3.1.1</version>
+    <version>1.3.2.0</version>
     <title>PSMake Testing mod</title>
     <authors>Wojciech Kotlarski</authors>
     <owners>Wojciech Kotlarski</owners>
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <description>A testing module for PsMake, allowing to execute nunit/nunit3/mbunit/mstest/xunit/dotnet tests with optional coverage check</description>
     <releaseNotes>Functions:
-   (Change) Run-OpenCover: added $profiler argument to support windows Local System account
+   (Change) Run-OpenCover: added -oldStyle flag to allow code coverage of .net core 2 assemblies.
 </releaseNotes>
   </metadata>
   <files>


### PR DESCRIPTION
Hi.
Currently, OpenCover can not calculate coverage for .net core 2 projects.
The solution I found here: https://github.com/OpenCover/opencover/issues/789
So, I've just added -oldStyle flag.
